### PR TITLE
dcqcn tweak and dashboard set to default

### DIFF
--- a/ai-cluster-jvd/configlet_dcqcn.tf
+++ b/ai-cluster-jvd/configlet_dcqcn.tf
@@ -1,6 +1,11 @@
 #
 # DCQCN configlet
-# 
+#
+# https://www.juniper.net/documentation/us/en/software/junos/traffic-mgmt-qfx/topics/topic-map/cos-qfx-series-DCQCN.html
+#
+# For more information on shared buffers for mostly lossless fabric:
+# https://www.juniper.net/documentation/us/en/software/junos/traffic-mgmt-qfx/topics/example/cos-shared-buffer-allocation-lossless-qfx-series-configuring.html
+#
 
 locals {
 
@@ -35,13 +40,10 @@ class-of-service {
         }
         egress {
             buffer-partition lossless {
-                percent 80;
+                percent 90;
             }
             buffer-partition lossy {
                 percent 10;
-            }
-            inactive: buffer-partition multicast {
-                inactive: percent 10;
             }
         }
     }

--- a/ai-cluster-jvd/iba.tf
+++ b/ai-cluster-jvd/iba.tf
@@ -144,7 +144,7 @@ resource "apstra_blueprint_iba_widget" "w_bandwidth_utilization" {
 resource "apstra_blueprint_iba_dashboard" "b" {
   count = length(local.blueprints)
   blueprint_id = local.blueprints[count.index].id
-  default = false
+  default = true
   description = "AI Dashboard with TF"
   name = "AI Dashboard with TF"
   widget_grid = tolist([


### PR DESCRIPTION
@rajagopalans I want to move the dashboard to default = true so it shows on the dashboard tab. I also tweaked the DCQCN shared buffer on egress to remove the multicast buffer that isn't supported on Junos Evolved